### PR TITLE
docs: mark V1 baseline and simplify ideas log

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -236,3 +236,28 @@
   - `assets/review_sets/set_d/*` (Donkey Runner)
   - generation tool: `assets/tools/generate_review_sets.py`
 - Current active runtime selection: `set_d` (Donkey Runner) copied to `assets/runtime/sprites/*`.
+
+## Session 2026-03-07
+
+### Topics & Decisions
+- Repository was hard-reset to `origin/master` and cleaned to remove local experimental deltas.
+- Current baseline is now treated as **V1** at commit `ff27383` (merge of PR #6).
+
+### V1 Sanity Snapshot
+- Git state: clean and aligned with `origin/master`.
+- Build tooling status in this environment: `cmake` is not installed, so configure/build/test could not be executed locally.
+- Static code sanity pass completed across:
+  - core loop/state: `src/main.c`, `src/game.c`
+  - gameplay systems: `src/player.c`, `src/obstacle.c`
+  - support modules: `src/animation.c`, `src/art_assets.c`, `src/audio_events.c`, `src/score_store.c`
+  - test surface: `tests/animation_test.c`
+
+### Open Items & TODOs
+- Install `cmake` in the execution environment and run:
+  - `cmake -S . -B build`
+  - `cmake --build build`
+  - `ctest --test-dir build --output-on-failure`
+- Add/expand deterministic gameplay tests beyond animation timing:
+  - collision edge cases
+  - obstacle spawn timing constraints
+  - score progression boundaries

--- a/ideas.md
+++ b/ideas.md
@@ -1,263 +1,106 @@
 # Ideas Log
 
-## Session 2026-02-13
+## Implemented Decisions
 
-### Topics & Ideas Discussed
-- Core direction: a polished Raylib runner inspired by Chrome Dino, with tight controls and fast restart loops.
-- Design pillar 1: immediate readability (clear obstacles, simple silhouettes, minimal UI).
-- Design pillar 2: mastery through rhythm (jump timing, duck timing, speed scaling).
-- Design pillar 3: short-session replayability (10-60 second runs, instant retry).
+### Product Direction
+- Build an arcade-tight 2D runner inspired by Chrome Dino.
+- Prioritize fast restart loops and short-session replayability.
+- Keep readability-first visuals and gameplay feedback.
 
-### Gameplay Brainstorm
-- Controls: `Space`/`Up` jump, `Down` duck, `R` restart.
-- Core obstacles: cactus variants (low), bird variants (mid/high lanes).
-- Difficulty curve: increase scroll speed over time, then add denser obstacle patterns.
-- Score model: distance-based score + milestone badges every 100 points.
-- States: title, run, game over, paused.
+### Core Gameplay
+- Controls:
+  - `Space`/`Up`: jump
+  - `Down`: duck
+  - any key on game-over: restart
+  - `D`: toggle debug hitboxes
+- MVP scope is strict:
+  - one biome
+  - cactus + bird obstacles
+  - distance score
+  - game-over and instant restart
+  - persistent best score
+- Score model is distance-only for MVP.
+- Difficulty uses stepped speed increases by score milestones.
 
-### Feature Ideas (Post-MVP)
-- Day/night cycle affecting palette and obstacle contrast.
-- Character skins unlocked via high score milestones.
-- Daily challenge seed (same obstacle sequence for all players that day).
-- Lightweight assist mode (slower acceleration) for accessibility.
+### Game Feel Tuning
+- Jump behavior: low jump with fast fall.
+- Input forgiveness: light jump buffer + short coyote time.
+- Duck behavior: hitbox/profile shrink only; no speed modifier.
+- Hitbox policy: hybrid (slightly forgiving player, near-strict obstacles).
+- Hit feedback: short freeze + tiny camera shake.
 
-### Open Items & TODOs
-- Decide visual direction: monochrome retro vs. minimal color accent.
-- Define final hitbox policy: forgiving vs. strict pixel-approximate.
-- Choose build/test stack (`Makefile` only or `CMake` + `ctest`).
-- Write first implementation tasks:
-  - Bootstrap `src/main.c` game loop and state machine.
-  - Add `player` module (jump physics, duck state).
-  - Add `obstacle` module (spawn, movement, despawn).
-  - Add collision checks + score tracking.
-  - Add restart flow and game-over UI.
+### Visual and Audio Direction
+- Visual style: pixel-inspired silhouettes with modern readability.
+- Palette strategy: single day palette for MVP.
+- Background treatment: minimal static background.
+- Player run cycle: 4 frames.
+- Bird animation: 3-frame flap.
+- Jump/land animation language: pose-based with small squash/stretch.
+- SFX scope: minimal event-driven SFX, no BGM.
+- SFX style: synthetic retro blips.
+- SFX variation policy: single sound per event.
+- Runtime audio format: OGG.
 
-### Topic-by-Topic Decisions
-- Topic 1 (Core game feel): **Arcade-tight** selected.
-  - Implementation direction: faster jump arc, stricter timing windows, strong speed escalation.
-  - Follow-up needed: finalize hitbox strictness and input buffering policy to support this feel.
-- Topic 2 (Hitbox policy): **Hybrid** selected.
-  - Implementation direction: slightly forgiving player hurtbox, near-strict obstacle hitboxes.
-  - Follow-up needed: choose exact shrink ratio (recommended start: player hurtbox at 85-90% of visual bounds).
-- Topic 3 (Input buffering / coyote time): **Light** selected.
-  - Implementation direction: add a small jump buffer and short coyote window to preserve responsiveness without removing challenge.
-  - Initial tuning target: 75ms jump buffer, 50ms coyote time.
-- Topic 4 (Difficulty ramp profile): **Stepped ramp** selected.
-  - Implementation direction: increase speed in discrete jumps at score milestones for clear pacing shifts.
-  - Initial tuning target: speed step every 100 points with capped max speed.
-- Topic 5 (Obstacle spawn logic): **Pure random with constraints for MVP**, plan to explore **Hybrid pattern + random variation** later.
-  - MVP direction: randomize obstacle type/gap with safety constraints to avoid impossible sequences.
-  - Later-phase direction: introduce curated pattern chunks and randomized micro-variation for better rhythm.
-- Topic 6 (Score model): **Distance only** selected for MVP.
-  - Implementation direction: score increases by survived distance/time only, with milestone feedback.
-  - Later-phase option: add bonus systems (near-miss/combo) only after core feel is stable.
-- Topic 7 (Visual direction): **Minimal color accent** selected.
-  - Implementation direction: keep clean, high-contrast visuals with restrained accent colors for feedback and identity.
-  - Asset implication: prioritize readability-first silhouettes before decorative detail.
-- Topic 8 (MVP scope boundary): **Strict MVP** selected.
-  - MVP includes: one biome, cactus+bird obstacles, distance score, game-over, and instant restart.
-  - Deferred features: pause menu, high-score persistence, day/night cycle, and skins.
-- Topic 9 (Technical baseline): **CMake-first** selected.
-  - Implementation direction: establish a scalable CMake project layout from the start.
-  - Immediate implications: standardize build presets/targets and keep testing hooks compatible with `ctest`.
-- Topic 10 (First playable milestone): **Core-loop-first** selected.
-  - Milestone includes: player controls, obstacle spawning, collision, game-over state, and instant restart.
-  - Success criteria: a complete playable loop with tunable parameters and stable frame pacing.
-- Topic 11 (Jump behavior tuning): **Low jump, fast fall** selected.
-  - Implementation direction: use a snappy jump arc with strong downward acceleration for precision play.
-  - Tuning priority: preserve input responsiveness while preventing floaty airtime.
-- Topic 12 (Duck mechanic behavior): **Pure hitbox shrink** selected.
-  - Implementation direction: duck only changes player profile/hurtbox, with no speed modifier.
-  - Design rationale: keeps readability high and preserves strict rhythm-based timing.
-- Topic 13 (Game-over restart UX): **Any-key restart** selected.
-  - Implementation direction: allow immediate restart from game-over with any gameplay-relevant key.
-  - UX rationale: minimize downtime and maximize rapid replay loops.
-- Topic 14 (MVP audio policy): **Minimal SFX only** selected.
-  - Implementation direction: include core feedback sounds (jump, hit, milestone/score cue) without background music.
-  - Scope rationale: improves game feel while keeping MVP production cost low.
-- Topic 15 (HUD scope for MVP): **Score + persistent best score** selected.
-  - Implementation direction: display current score and all-time best score in HUD.
-  - Technical implication: add lightweight local persistence for best score in MVP.
+### Platform and Runtime
+- Platform priority: web first, desktop later.
+- MVP targets: desktop + web compatibility in code path.
+- Web input scheme: keyboard-first.
+- Web performance target: 60 FPS with graceful degradation.
+- Browser support target: latest Chrome, Firefox, Safari.
+- Web high-score persistence: browser local storage.
+- Fixed-step simulation at 60 Hz with decoupled rendering.
 
-### Platform Discussion
-- Platform Topic A (Primary MVP target): **Desktop + Web** selected for first release.
-  - Implementation direction: keep core loop/input/render path compatible with native and HTML5/WebAssembly builds.
-  - Follow-up needed: define persistence fallback behavior for web vs desktop.
-- Platform Topic B (Web performance baseline): **60 FPS target with graceful degradation** selected.
-  - Implementation direction: design for 60 FPS by default while preserving playable behavior under occasional frame drops.
-  - Technical implication: keep update logic delta-time aware and avoid heavy per-frame allocations.
-- Platform Topic C (Web input scheme): **Keyboard only** selected.
-  - Implementation direction: keep input parity between desktop and web for MVP.
-  - Scope implication: defer mouse/touch controls until post-MVP validation.
-- Platform Topic D (Web deployment target): **S3 now, Itch.io end-goal** selected.
-  - Current workflow: deploy web builds to S3 for early access/testing.
-  - Final distribution goal: publish polished web build on Itch.io.
-- Platform Topic E (S3 release model): **Versioned builds + latest alias** selected.
-  - Status: superseded by later CI/CD update to `/<repo-name>/<version>/` deploy paths.
-  - Historical rationale: versioned artifacts support rollback and reproducible testing.
-- Platform Topic F (Web persistence for best score): **Browser local storage only** selected.
-  - Implementation direction: store best score client-side per browser/device for MVP.
-  - Scope rationale: avoids backend/API complexity in early releases.
-- Platform Topic G (Desktop distribution priority): **Web first**, Linux/macOS later.
-  - Release priority: focus initial launch and iteration loop on web builds.
-  - Desktop plan: add Linux/macOS native packaging in a later phase after web stabilization.
-- Platform Topic H (Web analytics for MVP): **None** selected.
-  - Implementation direction: ship without analytics instrumentation in MVP.
-  - Feedback source: rely on direct playtest feedback and manual observation initially.
-- Platform Topic I (S3 release channel): **Single public channel (`latest`)** selected.
-  - Status: superseded by later CI/CD update to explicit versioned release paths per deploy.
-  - Historical rationale: simplify early release operations.
-- Platform Topic J (Web build loading strategy): **Iteration-first** selected.
-  - Implementation direction: keep MVP pipeline simple with minimal load-time optimization initially.
-  - Follow-up plan: optimize compression/bundling after gameplay stability and deployment flow are validated.
-- Platform Topic K (Browser support target): **Latest Chrome + Firefox + Safari** selected.
-  - Implementation direction: validate MVP builds across all three major browsers before release.
-  - QA implication: include cross-browser smoke checks in the release checklist.
+### Build, Test, and Delivery
+- Build system baseline: CMake-first.
+- Include `ctest` integration from the start.
+- CI scope currently focuses on web build validation.
+- CD deploys versioned artifacts to `s3://<bucket>/<repo-name>/<version>/`.
+- Version resolution:
+  - `release/<version>` tag uses `<version>`
+  - otherwise use `yyyy-mm-dd-<short-sha>`
+- Deployment contract includes `index.html` at each version root.
+- CD also publishes deployment listings at repo root:
+  - `/<repo-name>/index.html`
+  - `/<repo-name>/deployments.json`
 
-### Implementation Notes
-- Implemented first playable skeleton with CMake, raylib modules, and gameplay loop:
-  - `src/main.c`, `src/game.c`, `src/player.c`, `src/obstacle.c`, `src/score_store.c`
-  - `include/game.h`, `include/player.h`, `include/obstacle.h`, `include/score_store.h`
-- Added documentation and pipeline scaffolding:
-  - `design.md` (consolidated spec), `build.md` (build/deploy guide), updated `README.md`
-  - `.github/workflows/ci-cd.yml` for CI + web artifact + S3 latest sync
-- Environment gap in this workspace: `cmake` is not installed locally, so configure/build could not be executed here.
+### Implemented Systems and Assets
+- Core modules implemented:
+  - `main`, `game`, `player`, `obstacle`, `score_store`
+  - `animation`, `art_assets`, `audio_events`
+- Automated test implemented:
+  - `animation_test`
+- Runtime assets integrated:
+  - player/obstacle sprite sheets
+  - jump/land/hit/milestone/restart OGG SFX
+- Active runtime sprite set: `set_d` (Donkey Runner).
 
-### CI/CD Updates
-- Removed desktop build from GitHub Actions for now.
-- CI now runs on branch pushes (web build validation only).
-- CD now runs on:
-  - every commit push on any branch
-  - every tag push
-- S3 deploy path changed to `/$repo-name/$version`, where:
-  - `$repo-name` is derived from the GitHub repository name
-  - `$version` is tag suffix for `release/<version>` when present, otherwise `yyyy-mm-dd-<short-sha>`
-- CD packaging requirement added:
-  - publish `index.html` as the entry page for each deployed version
-  - map `build-web/raylib_dino_runner.html` to `index.html` before S3 sync
+### Baseline Version
+- Baseline is treated as V1 at commit `ff27383` (`origin/master` snapshot).
 
-### Art / Animation / SFX Brainstorm (Kickoff)
-- Goal: define a cohesive aesthetic package that preserves readability and arcade-tight feel.
-- Constraints from prior decisions:
-  - Minimal color accent visual direction
-  - Web-first performance target (60 FPS with graceful degradation)
-  - MVP audio scope is SFX only (no BGM)
+## Backlog Decisions
 
-#### Candidate Art Directions
-- Direction A: clean flat silhouettes, warm accent (orange/red), subtle parallax bands.
-- Direction B: pixel-art inspired silhouettes with modern UI text and smooth camera feel.
-- Direction C: low-poly vector look with slightly exaggerated obstacle shapes.
+### Gameplay and Content
+- Evolve spawn logic from pure random constraints to hybrid pattern + random variation.
+- Add day/night palette cycle after MVP stabilization.
+- Add unlockable character skins tied to score milestones.
+- Add daily challenge seed mode.
+- Add optional assist mode (slower acceleration) for accessibility.
 
-#### Candidate Animation Language
-- Player: 2-3 frame run cycle, snappy jump takeoff frame, squash on landing.
-- Obstacles: mostly static readability-first; birds get 2-frame flap.
-- Feedback: short hit freeze (40-60ms), quick score milestone pop.
-
-#### Candidate SFX Set (MVP)
-- `jump`: short clicky whoosh
-- `land`: light thud
-- `hit`: sharp muted impact
-- `score_milestone`: concise UI ping
-- `restart`: soft confirm tick
-
-#### Open Art Pipeline Items
-- Decide source style: vector-first vs pixel-first.
-- Decide base resolution and scaling policy for web.
-- Define palette tokens (bg/fg/accent/warn).
-
-### Art Topic Decisions
-- Art Topic 1 (Primary visual direction): **Pixel-inspired silhouettes** selected.
-  - Direction: retro-flavored shapes with modern readability priorities.
-  - Implication: keep sprite counts low and silhouettes clear to protect web performance.
-- Art Topic 2 (Pixel density/base resolution): **Mid-res crisp** selected.
-  - Direction: target a ~480x270 style internal pixel grid with clean upscale behavior.
-  - Implication: better silhouette readability while retaining retro texture.
-- Art Topic 3 (Palette strategy): **Day palette only (MVP)** selected.
-  - Direction: single polished daytime palette for reliable readability and faster production.
-  - Deferred: night palette variants and dynamic cycling post-MVP.
-- Art Topic 4 (Background treatment): **Minimal static background** selected.
-  - Direction: keep background clean and low-detail to preserve obstacle readability.
-  - Scope benefit: lowest production and performance overhead for MVP.
-
-### Animation Topic Decisions
-- Animation Topic 1 (Player run cycle frame count): **4 frames** selected.
-  - Direction: smoother perceived motion while keeping asset scope manageable.
-  - Implementation note: keep timing consistent with arcade-tight feel and speed ramp readability.
-- Animation Topic 2 (Jump/land style): **Pose + small squash/stretch** selected.
-  - Direction: use restrained deformation to improve impact readability without cartoony excess.
-  - Implementation note: keep timing short to preserve snappy control response.
-- Animation Topic 3 (Bird obstacle animation): **3-frame flap** selected.
-  - Direction: provide smoother motion than 2-frame while keeping production cost controlled.
-  - Implementation note: prioritize clear wing silhouettes at high game speed.
-- Animation Topic 4 (Hit reaction feedback): **Short freeze + tiny camera shake** selected.
-  - Direction: add brief impact emphasis without overloading readability.
-  - Implementation note: keep freeze and shake amplitudes small for web comfort.
-
-### SFX Topic Decisions
-- SFX Topic 1 (Sound style): **Synthetic retro blips** selected.
-  - Direction: short, clean synthetic cues aligned with pixel-inspired presentation.
-  - Scope benefit: fast production and consistent tonal identity.
-- SFX Topic 2 (Loudness hierarchy): **Even loudness across all core SFX** selected.
-  - Direction: keep jump/hit/milestone/restart at similar perceived level for a flat mix baseline.
-  - Follow-up note: fine-tune per-event emphasis later during playtest if clarity issues appear.
-- SFX Topic 3 (Variation policy): **Single sound per event** selected.
-  - Direction: use one stable cue each for jump, land, hit, milestone, and restart in MVP.
-  - Scope benefit: reduces implementation complexity and QA surface.
-- SFX Topic 4 (Audio format for web-first MVP): **OGG only** selected.
-  - Direction: standardize SFX assets on OGG for smaller payload and web-first delivery.
-  - Pipeline note: keep source project files lossless externally; ship OGG runtime assets.
-
-### Art Direction Milestone 1 Implementation
-- Implemented fixed-step simulation (`60 Hz`) with decoupled render loop.
-- Added debug hitbox mode toggle via `D` key.
-- Added sprite/audio integration modules:
-  - `src/animation.c`, `src/art_assets.c`, `src/audio_events.c`
-  - `include/animation.h`, `include/art_assets.h`, `include/audio_events.h`
-- Added runtime placeholder assets:
-  - `assets/runtime/sprites/player.png`, `assets/runtime/sprites/obstacles.png`
-  - `assets/runtime/sfx/*.ogg` for jump/land/hit/milestone/restart
-- Added automated test:
-  - `tests/animation_test.c` registered in `ctest`
-- Updated CI/CD packaging to deploy `assets/runtime` together with `index.html`/JS/WASM.
-
-### Artwork Production Progress
-- Replaced placeholder sprite sheets with first production-style pixel art pass:
-  - `assets/runtime/sprites/player.png` (8-frame sheet: run/jump/duck/land/fall states)
-  - `assets/runtime/sprites/obstacles.png` (3 cactus variants + 3 bird flap frames)
-- Added reproducible generation script:
-  - `assets/tools/generate_pixel_art.py`
-- Compatibility validated:
-  - frame layout and dimensions unchanged (`player: 128x64`, `obstacles: 192x32`)
-  - build/test still passing after asset update
-- Created review branch asset candidates:
-  - `assets/review_sets/set_a/*` (Bold Contrast)
-  - `assets/review_sets/set_b/*` (Retro Soft)
-  - `assets/review_sets/set_c/*` (Arcade Punch)
-  - `assets/review_sets/set_d/*` (Donkey Runner)
-  - generation tool: `assets/tools/generate_review_sets.py`
-- Current active runtime selection: `set_d` (Donkey Runner) copied to `assets/runtime/sprites/*`.
-
-## Session 2026-03-07
-
-### Topics & Decisions
-- Repository was hard-reset to `origin/master` and cleaned to remove local experimental deltas.
-- Current baseline is now treated as **V1** at commit `ff27383` (merge of PR #6).
-
-### V1 Sanity Snapshot
-- Git state: clean and aligned with `origin/master`.
-- Build tooling status in this environment: `cmake` is not installed, so configure/build/test could not be executed locally.
-- Static code sanity pass completed across:
-  - core loop/state: `src/main.c`, `src/game.c`
-  - gameplay systems: `src/player.c`, `src/obstacle.c`
-  - support modules: `src/animation.c`, `src/art_assets.c`, `src/audio_events.c`, `src/score_store.c`
-  - test surface: `tests/animation_test.c`
-
-### Open Items & TODOs
-- Install `cmake` in the execution environment and run:
-  - `cmake -S . -B build`
-  - `cmake --build build`
-  - `ctest --test-dir build --output-on-failure`
-- Add/expand deterministic gameplay tests beyond animation timing:
+### Quality and Testing
+- Expand deterministic tests beyond animation:
   - collision edge cases
-  - obstacle spawn timing constraints
+  - obstacle spawn safety/timing constraints
   - score progression boundaries
+- Add broader gameplay-critical coverage before larger feature expansion.
+
+### Platform and Release
+- Keep S3 for iteration; publish polished build to Itch.io later.
+- Add Linux/macOS packaging after web stabilization.
+- Keep analytics out of MVP; reconsider post-MVP.
+- Improve web loading optimization after gameplay/deployment stability.
+
+### Infrastructure and Security
+- Replace static IAM key usage in CI/CD with GitHub OIDC role assumption.
+
+### Environment Gaps
+- Current local environment still needs `cmake` installed for full configure/build/test execution.


### PR DESCRIPTION
## Summary
- record the reset-to-master snapshot as the V1 baseline
- clean up ideas.md to be decisions-only
- organize decisions into Implemented and Backlog

## Why
- establish a stable baseline for iteration
- keep the decision log concise and actionable

## Validation
- documentation-only changes
- no runtime behavior changes